### PR TITLE
Use state param in auth flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,8 @@ var strategy = new Auth0Strategy({
     domain:       process.env.AUTH0_DOMAIN,
     clientID:     process.env.AUTH0_CLIENT_ID,
     clientSecret: process.env.AUTH0_CLIENT_SECRET,
-    callbackURL:  `http://${process.env.ROOT_DOMAIN}:${process.env.PORT}/callback`
+    callbackURL:  `http://${process.env.ROOT_DOMAIN}:${process.env.PORT}/callback`, 
+    state: true
   }, function(accessToken, refreshToken, extraParams, profile, done) {
     // accessToken is the token to call Auth0 API (not needed in the most cases)
     // extraParams.id_token has the JSON Web Token

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,6 @@
 var express = require('express');
 var passport = require('passport');
 var router = express.Router();
-var querystring = require('querystring');
 
 var tenant = require('../lib/tenant');
 
@@ -18,19 +17,13 @@ router.get('/',
 /* GET login page. */
 router.get('/login',
   tenant.setCurrent(),
-  function(req, res) {
+  function(req, res, next) {
     // use session to pass login tenant (if one exists) through login flow
     req.session.loginTenant = req.tenant;
 
-    var query = querystring.stringify({
-      client_id: process.env.AUTH0_CLIENT_ID,
-      response_type: 'code',
-      scopes: 'openid profile bar',
-      redirect_uri: `http://${process.env.ROOT_DOMAIN}:${process.env.PORT}/callback`
-    });
-
-    res.redirect(`https://${process.env.AUTH0_DOMAIN}/authorize?${query}`);
-  });
+    next();
+  },
+  passport.authenticate('auth0'));
 
 /* GET logout page. */
 router.get('/logout', 


### PR DESCRIPTION
Also switch to calling `passport.authenticate()` in the `/login` endpoint instead of constructing the /authorize request by hand.

Closes #12 